### PR TITLE
Migrate bitcoind calls to bitcore

### DIFF
--- a/.addrindex-server.yaml
+++ b/.addrindex-server.yaml
@@ -1,4 +1,4 @@
-host: 104.198.100.79:8332
+host: 35.185.104.76:8332
 usr: blockstack
 pass: blockstacksystem
 ssl: false

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VET_REPORT = vet.report
 TEST_REPORT = tests.xml
 GOARCH = amd64
 
-VERSION=0.13.0.2
+VERSION=0.14.1-bitcore
 COMMIT=$(shell git rev-parse HEAD)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ pass: password
 ssl: false
 port: 18332
 
-# The number of transactions to return with each request
-# This affects the /addr/ routes and no other ones
-transactions: 50
+# Timeout for refreshing block and currency price data
+timeout: 300
 ```
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `addrindex-server`
 
-This is a server to pair with an individual `bitcoind` node with the `addrindex` patch enabled. 
+This is a server to pair with an individual `bitcoind` with the [extra `bitcore` methods](https://bitcore.io/guides/bitcoin/) enabled. 
 
 ### Configuration
 
@@ -21,104 +21,12 @@ transactions: 50
 ### Build
 
 To build the project have a working gopath and run `make`
+To build the docker image have docker installed and run `make docker`
 
 ### Notes:
 
-- `/tx/{txid}` route has some differences with the insight api. Looks like theres some data enrichment going on
+- `GET /addr/<addr>/utxo` returns utxo from addresses that have been included in the last block. To prove, get the block at chain tip, pull a transaction from the list and grab the address from one of the UTXOs there. Then fetch the UTXOs for that address and make sure it's there. The following is a `bitcoin-cli` implementation of that:
 
-> curl -s utxo.technofractal.com:18332/tx/f7cbe7871abc534e5fa287e26973a1ba076783fbad392665211c9b8bfca79d7c | jq
-
-```json
-{
-  "hex": "0200000001440e64146e72439da521dc20f246a8d4b3bcf5ead4dc6a09523fa498fab10ef10000000088453042021e6fcf15e8d272d1a995af6fcc9d6c0c2f4c0b6b0525142e8af866dd8dad4b022059181242d993aa5101bab12ee86e7df0ce2dc308db930af9278b84d634fdeb45014104af0f6203b43276804c2cbbda0d10c797e61805b56e7abb5dd0cd90f69113dc1bbbaa4bae9c7eee1fde4cab190d54a0da60bca489702a8f7daa895fcaebd2b136ffffffff0134760000000000001976a91428dc4730af1538b45ee1f0e3df7a9c9f31b000a388ac00000000",
-  "txid": "f7cbe7871abc534e5fa287e26973a1ba076783fbad392665211c9b8bfca79d7c",
-  "hash": "f7cbe7871abc534e5fa287e26973a1ba076783fbad392665211c9b8bfca79d7c",
-  "size": 221,
-  "vsize": 221,
-  "version": 2,
-  "locktime": 0,
-  "vin": [
-    {
-      "txid": "f10eb1fa98a43f52096adcd4eaf5bcb3d4a846f220dc21a59d43726e14640e44",
-      "vout": 0,
-      "scriptSig": {
-        "asm": "3042021e6fcf15e8d272d1a995af6fcc9d6c0c2f4c0b6b0525142e8af866dd8dad4b022059181242d993aa5101bab12ee86e7df0ce2dc308db930af9278b84d634fdeb45[ALL] 04af0f6203b43276804c2cbbda0d10c797e61805b56e7abb5dd0cd90f69113dc1bbbaa4bae9c7eee1fde4cab190d54a0da60bca489702a8f7daa895fcaebd2b136",
-        "hex": "453042021e6fcf15e8d272d1a995af6fcc9d6c0c2f4c0b6b0525142e8af866dd8dad4b022059181242d993aa5101bab12ee86e7df0ce2dc308db930af9278b84d634fdeb45014104af0f6203b43276804c2cbbda0d10c797e61805b56e7abb5dd0cd90f69113dc1bbbaa4bae9c7eee1fde4cab190d54a0da60bca489702a8f7daa895fcaebd2b136"
-      },
-      "sequence": 4294967295
-    }
-  ],
-  "vout": [
-    {
-      "value": 0.0003026,
-      "n": 0,
-      "scriptPubKey": {
-        "asm": "OP_DUP OP_HASH160 28dc4730af1538b45ee1f0e3df7a9c9f31b000a3 OP_EQUALVERIFY OP_CHECKSIG",
-        "hex": "76a91428dc4730af1538b45ee1f0e3df7a9c9f31b000a388ac",
-        "reqSigs": 1,
-        "type": "pubkeyhash",
-        "addresses": [
-          "14j3us479jTySjG6Tr4uY4Nrx37iTM8QHF"
-        ]
-      }
-    }
-  ],
-  "blockhash": "00000000000000000063612423ef57aecfa050f4b7bd096024cb09323cea0593",
-  "confirmations": 1248,
-  "time": 1517865386,
-  "blocktime": 1517865386
-}
 ```
-
-> curl -sL explorer.blockstack.org/insight-api/tx/f7cbe7871abc534e5fa287e26973a1ba076783fbad392665211c9b8bfca79d7c | jq
-
-```json
-{
-  "txid": "f7cbe7871abc534e5fa287e26973a1ba076783fbad392665211c9b8bfca79d7c",
-  "version": 2,
-  "locktime": 0,
-  "vin": [
-    {
-      "txid": "f10eb1fa98a43f52096adcd4eaf5bcb3d4a846f220dc21a59d43726e14640e44",
-      "vout": 0,
-      "sequence": 4294967295,
-      "n": 0,
-      "scriptSig": {
-        "hex": "453042021e6fcf15e8d272d1a995af6fcc9d6c0c2f4c0b6b0525142e8af866dd8dad4b022059181242d993aa5101bab12ee86e7df0ce2dc308db930af9278b84d634fdeb45014104af0f6203b43276804c2cbbda0d10c797e61805b56e7abb5dd0cd90f69113dc1bbbaa4bae9c7eee1fde4cab190d54a0da60bca489702a8f7daa895fcaebd2b136",
-        "asm": "3042021e6fcf15e8d272d1a995af6fcc9d6c0c2f4c0b6b0525142e8af866dd8dad4b022059181242d993aa5101bab12ee86e7df0ce2dc308db930af9278b84d634fdeb45[ALL] 04af0f6203b43276804c2cbbda0d10c797e61805b56e7abb5dd0cd90f69113dc1bbbaa4bae9c7eee1fde4cab190d54a0da60bca489702a8f7daa895fcaebd2b136"
-      },
-      "addr": "1FLAMEN6rq2BqMnkUmsJBqCGWdwgVKcegd",
-      "valueSat": 35600,
-      "value": 0.000356,
-      "doubleSpentTxID": null
-    }
-  ],
-  "vout": [
-    {
-      "value": "0.00030260",
-      "n": 0,
-      "scriptPubKey": {
-        "hex": "76a91428dc4730af1538b45ee1f0e3df7a9c9f31b000a388ac",
-        "asm": "OP_DUP OP_HASH160 28dc4730af1538b45ee1f0e3df7a9c9f31b000a3 OP_EQUALVERIFY OP_CHECKSIG",
-        "addresses": [
-          "14j3us479jTySjG6Tr4uY4Nrx37iTM8QHF"
-        ],
-        "type": "pubkeyhash"
-      },
-      "spentTxId": null,
-      "spentIndex": null,
-      "spentHeight": null
-    }
-  ],
-  "blockhash": "00000000000000000063612423ef57aecfa050f4b7bd096024cb09323cea0593",
-  "blockheight": 507850,
-  "confirmations": 1248,
-  "time": 1517865386,
-  "blocktime": 1517865386,
-  "valueOut": 0.0003026,
-  "size": 221,
-  "valueIn": 0.000356,
-  "fees": 5.34e-05
-}
+bitcoin-cli getaddressutxos "{\"addresses\": [\"$(bitcoin-cli getrawtransaction $(bitcoin-cli getblock $(bitcoin-cli getchaintips | jq -r '.[].hash') | jq -r '.tx[0]') 1 | jq -r '.vout[0].scriptPubKey.addresses[0]')\"]}"
 ```
-

--- a/addrindex/addrhandlers.go
+++ b/addrindex/addrhandlers.go
@@ -62,7 +62,7 @@ func (as *AddrServer) HandleAddrUTXO(w http.ResponseWriter, r *http.Request) {
 
 	// If there are no mempool transactions then just return the historical
 	if len(mptxns.Result) < 1 {
-		var o UTXOInsOuts
+		o := UTXOInsOuts{}
 		for _, utxo := range txns.Result {
 			o = append(o, utxo.Enrich(info.Blocks))
 		}
@@ -123,6 +123,12 @@ func (as *AddrServer) HandleAddrUnconfirmedBalance(w http.ResponseWriter, r *htt
 
 	out, _ := json.Marshal(unconfirmed)
 	w.Write(out)
+}
+
+// HandleGetBlocks handles the /blocks route
+func (as *AddrServer) HandleGetBlocks(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(as.Blocks.JSON())
 }
 
 // HandleAddrBalance handles the /addr/<addr>/balance route
@@ -341,8 +347,8 @@ func (as *AddrServer) HandleGetBlockHash(w http.ResponseWriter, r *http.Request)
 	w.Write(bh)
 }
 
-// GetSync handles the /sync route
-func (as *AddrServer) GetSync(w http.ResponseWriter, r *http.Request) {
+// HandleGetSync handles the /sync route
+func (as *AddrServer) HandleGetSync(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	chainInfo, err := as.Client.GetBlockChainInfo()
@@ -355,8 +361,8 @@ func (as *AddrServer) GetSync(w http.ResponseWriter, r *http.Request) {
 	w.Write(NewSyncResponse(chainInfo))
 }
 
-// GetStatus handles the /status route
-func (as *AddrServer) GetStatus(w http.ResponseWriter, r *http.Request) {
+// HandleGetStatus handles the /status route
+func (as *AddrServer) HandleGetStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	query := r.URL.Query()
 	method := "getInfo"
@@ -394,8 +400,8 @@ func (as *AddrServer) GetStatus(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// GetTransactions handles the /txs route
-func (as *AddrServer) GetTransactions(w http.ResponseWriter, r *http.Request) {
+// HandleGetTransactions handles the /txs route
+func (as *AddrServer) HandleGetTransactions(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	query := r.URL.Query()
@@ -539,28 +545,10 @@ func (as *AddrServer) GetTransactions(w http.ResponseWriter, r *http.Request) {
 	w.Write(NewPostError("Need to pass ?block=BLOCKHASH or ?address=ADDR", fmt.Errorf("")))
 }
 
-// GetVersion handles the /version route
-func (as *AddrServer) GetVersion(w http.ResponseWriter, r *http.Request) {
+// HandleGetVersion handles the /version route
+func (as *AddrServer) HandleGetVersion(w http.ResponseWriter, r *http.Request) {
 	w.Write(as.version())
 }
-
-// /insight-api/version
-// GET /version
-// router.HandleFunc("/version", as.GetVersion).Methods("GET")
-
-// router.HandleFunc("/addr/{addr}/unconfirmedBalance", as.HandleAddrUnconfirmed).Methods("GET")
-
-// NOTE: This pulls data from outside price APIs. Might want to implement a couple
-// NOTE: Lets cache this data server side the same way we are doing with the block index
-// GET /currency
-// router.HandleFunc("/currency", as.GetCurrency).Methods("GET")
-// curl https://www.bitstamp.net/api/v2/ticker/btcusd/
-// curl https://blockchain.info/ticker
-// curl https://api.coindesk.com/v1/bpi/currentprice/usd.json
-
-// /insight-api/blocks?limit=3&blockDate=2016-04-22
-// NOTE: We are going to need to keep a cache of this data on the server
-// router.HandleFunc("/blocks", as.HandleGetBlocksByDate).Methods("GET")
 
 // TxPost models a post request for sending a transaction
 type TxPost struct {
@@ -641,4 +629,9 @@ func NewSyncResponse(bc *btcjson.GetBlockChainInfoResult) []byte {
 		Type:             "addrindex-server",
 	})
 	return out
+}
+
+// HandleGetCurrency handles the /currency route
+func (as *AddrServer) HandleGetCurrency(w http.ResponseWriter, r *http.Request) {
+	w.Write(as.CurrencyData.JSON())
 }

--- a/addrindex/addrhandlers.go
+++ b/addrindex/addrhandlers.go
@@ -54,7 +54,7 @@ func (as *AddrServer) HandleTest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var retTxns []string
-	var out []GetRawTransactionResponse
+	var out []TransactionIns
 
 	// Pull off a page of transactions
 	if len(txns.Result) < 10 {
@@ -418,7 +418,7 @@ func (as *AddrServer) GetTransactions(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var retTxns []string
-		var out []GetRawTransactionResponse
+		var out []TransactionIns
 
 		// Pull off a page of transactions
 		if len(txns.Result) < 10 {

--- a/addrindex/addrhandlers.go
+++ b/addrindex/addrhandlers.go
@@ -32,54 +32,54 @@ import (
 const BlockstackStartBlock = 373601
 
 // HandleTest handles the test route
-func (as *AddrServer) HandleTest(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	addr := mux.Vars(r)["addr"]
-	page := 0
-
-	// Fetch Block Height
-	info, err := as.Client.GetInfo()
-	if err != nil {
-		w.WriteHeader(400)
-		w.Write(NewPostError("failed to getInfo", err))
-		return
-	}
-
-	// paginate through transactions
-	txns, err := as.GetAddressTxIDs([]string{addr}, BlockstackStartBlock, int(info.Blocks))
-	if err != nil {
-		w.WriteHeader(400)
-		w.Write(NewPostError("error fetching page of transactions for address", err))
-		return
-	}
-
-	var retTxns []string
-	var out []TransactionIns
-
-	// Pull off a page of transactions
-	if len(txns.Result) < 10 {
-		retTxns = txns.Result
-	} else if len(txns.Result) > ((page + 1) * 10) {
-		retTxns = []string{}
-	} else if len(txns.Result) > (page*10) && len(txns.Result) < ((page+1)*10) {
-		retTxns = txns.Result[page*10:]
-	} else {
-		retTxns = txns.Result[page*10 : (page+1)*10]
-	}
-
-	for _, txid := range retTxns {
-		tx, err := as.GetRawTransaction(txid)
-		if err != nil {
-			w.WriteHeader(400)
-			w.Write(NewPostError("error fetching page of transactions for address", err))
-			return
-		}
-		out = append(out, tx.Result)
-	}
-
-	o, _ := json.Marshal(out)
-	w.Write(o)
-}
+// func (as *AddrServer) HandleTest(w http.ResponseWriter, r *http.Request) {
+// 	w.Header().Set("Content-Type", "application/json")
+// 	addr := mux.Vars(r)["addr"]
+// 	page := 0
+//
+// 	// Fetch Block Height
+// 	info, err := as.Client.GetInfo()
+// 	if err != nil {
+// 		w.WriteHeader(400)
+// 		w.Write(NewPostError("failed to getInfo", err))
+// 		return
+// 	}
+//
+// 	// paginate through transactions
+// 	txns, err := as.GetAddressTxIDs([]string{addr}, BlockstackStartBlock, int(info.Blocks))
+// 	if err != nil {
+// 		w.WriteHeader(400)
+// 		w.Write(NewPostError("error fetching page of transactions for address", err))
+// 		return
+// 	}
+//
+// 	var retTxns []string
+// 	var out []TransactionIns
+//
+// 	// Pull off a page of transactions
+// 	if len(txns.Result) < 10 {
+// 		retTxns = txns.Result
+// 	} else if len(txns.Result) > ((page + 1) * 10) {
+// 		retTxns = []string{}
+// 	} else if len(txns.Result) > (page*10) && len(txns.Result) < ((page+1)*10) {
+// 		retTxns = txns.Result[page*10:]
+// 	} else {
+// 		retTxns = txns.Result[page*10 : (page+1)*10]
+// 	}
+//
+// 	for _, txid := range retTxns {
+// 		tx, err := as.GetRawTransaction(txid)
+// 		if err != nil {
+// 			w.WriteHeader(400)
+// 			w.Write(NewPostError("error fetching page of transactions for address", err))
+// 			return
+// 		}
+// 		out = append(out, tx.Result)
+// 	}
+//
+// 	o, _ := json.Marshal(out)
+// 	w.Write(o)
+// }
 
 // HandleAddrUTXO handles the /addr/<addr>/utxo route
 func (as *AddrServer) HandleAddrUTXO(w http.ResponseWriter, r *http.Request) {
@@ -178,6 +178,7 @@ func (as *AddrServer) HandleRawTxGet(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleTransactionSend handles the /tx/send route
+// TODO: Write a test for this
 func (as *AddrServer) HandleTransactionSend(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var tx TxPost
@@ -226,7 +227,7 @@ func (as *AddrServer) HandleTransactionSend(w http.ResponseWriter, r *http.Reque
 }
 
 // HandleMessagesVerify handles the /messages/verify route
-// TODO: Test this somehow?
+// TODO: Write a test for this
 func (as *AddrServer) HandleMessagesVerify(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	var tx VerifyPost

--- a/addrindex/addrhandlers.go
+++ b/addrindex/addrhandlers.go
@@ -128,7 +128,18 @@ func (as *AddrServer) HandleAddrUnconfirmedBalance(w http.ResponseWriter, r *htt
 // HandleGetBlocks handles the /blocks route
 func (as *AddrServer) HandleGetBlocks(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(as.Blocks.JSON())
+	query := r.URL.Query()
+	limit := "10"
+	if len(query["limit"]) > 0 {
+		limit = query["limit"][0]
+	}
+	lim, err := strconv.ParseInt(limit, 10, 64)
+	if err != nil {
+		w.WriteHeader(400)
+		w.Write(NewPostError("failed parsing ?limit={val}", err))
+		return
+	}
+	w.Write(as.GetBlocksResponse(lim))
 }
 
 // HandleAddrBalance handles the /addr/<addr>/balance route
@@ -633,5 +644,7 @@ func NewSyncResponse(bc *btcjson.GetBlockChainInfoResult) []byte {
 
 // HandleGetCurrency handles the /currency route
 func (as *AddrServer) HandleGetCurrency(w http.ResponseWriter, r *http.Request) {
-	w.Write(as.CurrencyData.JSON())
+	cd := NewCurrencyData()
+	cd.Status = 200
+	w.Write(cd.JSON())
 }

--- a/addrindex/addrhandlers_test.go
+++ b/addrindex/addrhandlers_test.go
@@ -34,12 +34,13 @@ var (
 )
 
 func handlerTestSetup() (*AddrServer, *httptest.Server) {
-	as := NewAddrServer(&AddrServerConfig{
+	as := NewTestAddrServer(&AddrServerConfig{
 		Host:    testServer,
 		Usr:     testUser,
 		Pass:    testPass,
 		SSL:     testSSL,
 		Port:    testPort,
+		Timeout: 300,
 		Version: "test",
 		Commit:  "test",
 		Branch:  "test",

--- a/addrindex/addrhandlers_test.go
+++ b/addrindex/addrhandlers_test.go
@@ -1,0 +1,320 @@
+package addrindex
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcjson"
+)
+
+var (
+	testServer              = "35.227.54.185:8332"
+	testPass                = "blockstacksystem"
+	testUser                = "blockstack"
+	testSSL                 = false
+	testPort                = 18332
+	testAddress             = "1E2vd1baZLrhNRgU6FPZv1zxxuRNhj4btG"
+	testExpectedUTXO        = 1
+	testExpectedUTXOSatoshi = 1127408
+	testExpectedBalance     = 1127408
+	testExpectedReceived    = 9151137107
+	testExpectedSent        = 9150009699
+	testTransaction         = "a75aceccabf4b44d82cd72fef667a394dc898f59553ddd4356edf4f4bdc267ae"
+	testExpectedTxSatoshi   = 990420
+	testBlock               = "000000000000000004ec466ce4732fe6f1ed1cddc2ed4b328fff5224276e3f6f"
+	testExpectedBlockTx     = 1660
+	testExpectedBlockNonce  = uint32(657220870)
+	testExpectedBlockHash   = "0100000001ab3e33c13344dde0794a3a1ea03d9f1335a2a08d762b70d943527e9ce9421bc5020000006b483045022100db58090a26c9e3fcbd000c3000210ba7050df65b68e1745b54b695579e2615e00220109b2225eda4c12accf537d16023008121587e61d942494bf02ef3c8667f0a270121023beb2a616698c02d6f64c1ca11a5cccfd722563caccc6a7b5eabd9c6c4158feeffffffff020000000000000000296a2769642bc318e73d4f47f8474028190f1561d9b5319564146d3d4ab1283228a26e82641e96b290ee50b50e00000000001976a9148ef6cfc4c8ee2e6142001c94275ff47d3f05886588ac00000000"
+	testBlockIndex          = 400000
+)
+
+func handlerTestSetup() (*AddrServer, *httptest.Server) {
+	as := NewAddrServer(&AddrServerConfig{
+		Host:    testServer,
+		Usr:     testUser,
+		Pass:    testPass,
+		SSL:     testSSL,
+		Port:    testPort,
+		Version: "test",
+		Commit:  "test",
+		Branch:  "test",
+	})
+	return as, httptest.NewServer(as.Router())
+}
+
+func TestHandleAddrUTXO(t *testing.T) {
+	t.Parallel()
+	_, server := handlerTestSetup()
+	defer server.Close()
+	tempString := "%s/addr/%s/utxo"
+
+	// Make HTTP request to route
+	resp, err := http.Get(fmt.Sprintf(tempString, server.URL, testAddress))
+	if resp.StatusCode != 200 {
+		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
+	} else if err != nil {
+		t.Fatalf("Error making HTTP call to server: %s\n", err.Error())
+	}
+
+	// Read the body
+	actual, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed Reading Response Body: %s\n", err.Error())
+	}
+
+	// Unmarshal the response into proper struct
+	resStruct := []UTXOIns{}
+	err = json.Unmarshal(actual, &resStruct)
+	if err != nil {
+		t.Fatalf("Failed Unmarshalling response: %s\n", err.Error())
+	}
+
+	// Check response values for accuracy
+	expectedUTXO := testExpectedUTXO
+	if len(resStruct) != expectedUTXO {
+		t.Errorf("Expected '%d' utxo, got '%d'\n", expectedUTXO, len(resStruct))
+	}
+
+	// Check response values for accuracy
+	if resStruct[0].Satoshis != testExpectedUTXOSatoshi {
+		t.Errorf("Expected '%d' satoshi, got '%d'\n", testExpectedUTXOSatoshi, resStruct[0].Satoshis)
+	}
+}
+
+func TestHandleAddrBalance(t *testing.T) {
+	t.Parallel()
+	_, server := handlerTestSetup()
+	defer server.Close()
+	tempString := "%s/addr/%s/balance"
+
+	// Make HTTP request to route
+	resp, err := http.Get(fmt.Sprintf(tempString, server.URL, testAddress))
+	if resp.StatusCode != 200 {
+		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
+	} else if err != nil {
+		t.Fatalf("Error making HTTP call to server: %s\n", err.Error())
+	}
+
+	// Read the body
+	actual, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed Reading Response Body: %s\n", err.Error())
+	}
+
+	// Unmarshal the response into proper struct
+	retVal, err := strconv.ParseInt(string(actual), 10, 64)
+	if err != nil {
+		t.Fatalf("Failed Parsing Balance: %s\n", err.Error())
+	}
+
+	// Check response values for accuracy
+	if int(retVal) != testExpectedBalance {
+		t.Errorf("Expected balance '%d', got '%d'\n", testExpectedBalance, retVal)
+	}
+}
+
+func TestHandleAddrRecieved(t *testing.T) {
+	t.Parallel()
+	_, server := handlerTestSetup()
+	defer server.Close()
+	tempString := "%s/addr/%s/totalReceived"
+
+	// Make HTTP request to route
+	resp, err := http.Get(fmt.Sprintf(tempString, server.URL, testAddress))
+	if resp.StatusCode != 200 {
+		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
+	} else if err != nil {
+		t.Fatalf("Error making HTTP call to server: %s\n", err.Error())
+	}
+
+	// Read the body
+	actual, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed Reading Response Body: %s\n", err.Error())
+	}
+
+	// Unmarshal the response into proper struct
+	retVal, err := strconv.ParseInt(string(actual), 10, 64)
+	if err != nil {
+		t.Fatalf("Failed Parsing Balance: %s\n", err.Error())
+	}
+
+	// Check response values for accuracy
+	if int(retVal) != testExpectedReceived {
+		t.Errorf("Expected balance '%d', got '%d'\n", testExpectedReceived, retVal)
+	}
+}
+
+func TestHandleAddrSent(t *testing.T) {
+	t.Parallel()
+	_, server := handlerTestSetup()
+	defer server.Close()
+	tempString := "%s/addr/%s/totalSent"
+
+	// Make HTTP request to route
+	resp, err := http.Get(fmt.Sprintf(tempString, server.URL, testAddress))
+	if resp.StatusCode != 200 {
+		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
+	} else if err != nil {
+		t.Fatalf("Error making HTTP call to server: %s\n", err.Error())
+	}
+
+	// Read the body
+	actual, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed Reading Response Body: %s\n", err.Error())
+	}
+
+	// Unmarshal the response into proper struct
+	retVal, err := strconv.ParseInt(string(actual), 10, 64)
+	if err != nil {
+		t.Fatalf("Failed Parsing Balance: %s\n", err.Error())
+	}
+
+	// Check response values for accuracy
+	if int(retVal) != testExpectedSent {
+		t.Errorf("Expected balance '%d', got '%d'\n", testExpectedSent, retVal)
+	}
+}
+
+func TestHandleTxGet(t *testing.T) {
+	t.Parallel()
+	_, server := handlerTestSetup()
+	defer server.Close()
+	tempString := "%s/tx/%s"
+
+	// Make HTTP request to route
+	resp, err := http.Get(fmt.Sprintf(tempString, server.URL, testTransaction))
+	if resp.StatusCode != 200 {
+		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
+	} else if err != nil {
+		t.Fatalf("Error making HTTP call to server: %s\n", err.Error())
+	}
+
+	// Read the body
+	actual, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed Reading Response Body: %s\n", err.Error())
+	}
+
+	// Unmarshal the response into proper struct
+	resStruct := TransactionIns{}
+	err = json.Unmarshal(actual, &resStruct)
+	if err != nil {
+		t.Fatalf("Failed Unmarshalling response: %s\n", err.Error())
+	}
+
+	// Check response values for accuracy
+	if resStruct.Vin[0].ValueSat != testExpectedTxSatoshi {
+		t.Errorf("Expected '%d' satoshi, got '%d'\n", testExpectedTxSatoshi, resStruct.Vin[0].ValueSat)
+	}
+}
+
+func TestHandleRawTxGet(t *testing.T) {
+	t.Parallel()
+	_, server := handlerTestSetup()
+	defer server.Close()
+	tempString := "%s/rawtx/%s"
+
+	// Make HTTP request to route
+	resp, err := http.Get(fmt.Sprintf(tempString, server.URL, testTransaction))
+	if resp.StatusCode != 200 {
+		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
+	} else if err != nil {
+		t.Fatalf("Error making HTTP call to server: %s\n", err.Error())
+	}
+
+	// Read the body
+	actual, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed Reading Response Body: %s\n", err.Error())
+	}
+
+	// Unmarshal the response into proper struct
+	resStruct := map[string]string{}
+	err = json.Unmarshal(actual, &resStruct)
+	if err != nil {
+		t.Fatalf("Failed Unmarshalling response: %s\n", err.Error())
+	}
+
+	// Check response values for accuracy
+	if resStruct["rawtx"] != testExpectedBlockHash {
+		t.Errorf("Expected '%s' satoshi, got '%s'\n", testExpectedBlockHash, resStruct["rawtx"])
+	}
+}
+
+func TestHandleGetBlock(t *testing.T) {
+	t.Parallel()
+	_, server := handlerTestSetup()
+	defer server.Close()
+	tempString := "%s/block/%s"
+
+	// Make HTTP request to route
+	resp, err := http.Get(fmt.Sprintf(tempString, server.URL, testBlock))
+	if resp.StatusCode != 200 {
+		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
+	} else if err != nil {
+		t.Fatalf("Error making HTTP call to server: %s\n", err.Error())
+	}
+
+	// Read the body
+	actual, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed Reading Response Body: %s\n", err.Error())
+	}
+
+	// Unmarshal the response into proper struct
+	resStruct := btcjson.GetBlockVerboseResult{}
+	err = json.Unmarshal(actual, &resStruct)
+	if err != nil {
+		t.Fatalf("Failed Unmarshalling response: %s\n", err.Error())
+	}
+
+	// Check response values for accuracy
+	if len(resStruct.Tx) != testExpectedBlockTx {
+		t.Errorf("Expected '%d' utxo, got '%d'\n", testExpectedBlockTx, len(resStruct.Tx))
+	}
+
+	// Check response values for accuracy
+	if resStruct.Nonce != testExpectedBlockNonce {
+		t.Errorf("Expected '%d' satoshi, got '%d'\n", testExpectedBlockNonce, resStruct.Nonce)
+	}
+}
+
+func TestHandleGetBlockHash(t *testing.T) {
+	t.Parallel()
+	_, server := handlerTestSetup()
+	defer server.Close()
+	tempString := "%s/block-index/%d"
+
+	// Make HTTP request to route
+	resp, err := http.Get(fmt.Sprintf(tempString, server.URL, testBlockIndex))
+	if resp.StatusCode != 200 {
+		t.Fatalf("Received non-200 response: %d\n", resp.StatusCode)
+	} else if err != nil {
+		t.Fatalf("Error making HTTP call to server: %s\n", err.Error())
+	}
+
+	// Read the body
+	actual, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed Reading Response Body: %s\n", err.Error())
+	}
+
+	// Unmarshal the response into proper struct
+	resStruct := map[string]string{}
+	err = json.Unmarshal(actual, &resStruct)
+	if err != nil {
+		t.Fatalf("Failed Unmarshalling response: %s\n", err.Error())
+	}
+
+	// Check response values for accuracy
+	if resStruct["blockHash"] != testBlock {
+		t.Errorf("Expected '%s' satoshi, got '%s'\n", testBlock, resStruct["blockHash"])
+	}
+}

--- a/addrindex/addrserver.go
+++ b/addrindex/addrserver.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/gorilla/mux"
 )
 
 // AddrServer is the struct where all methods are defined
@@ -99,34 +100,36 @@ func (as *AddrServer) connCfg() *rpcclient.ConnConfig {
 	}
 }
 
-// fetchAllTransactions pages through the transactions for an address
-// NOTE: This can take a long time!
-// func (as *AddrServer) fetchAllTransactions(addr string) (Transactions, error) {
-// 	txns := []Transaction{}
-// 	count := 0
-// 	for {
-// 		// Fetch page of transactions
-// 		searchtxns, err := as.SearchRawTransactions(addr, (count * as.Transactions), as.Transactions)
-// 		if err != nil {
-// 			return nil, err
-// 		}
-//
-// 		// Increment page count
-// 		count++
-//
-// 		// If the page is full we need to append them and continue to next page
-// 		if len(searchtxns.Result) == as.Transactions {
-// 			for _, tx := range searchtxns.Result {
-// 				txns = append(txns, tx)
-// 			}
-// 			continue
-// 		}
-//
-// 		// If not we need to save the tansactions and return
-// 		for _, tx := range searchtxns.Result {
-// 			txns = append(txns, tx)
-// 		}
-//
-// 		return txns, nil
-// 	}
-// }
+// Router holds the routing table for the AddrServer
+func (as *AddrServer) Router() *mux.Router {
+	router := mux.NewRouter()
+
+	router.HandleFunc("/addr/{addr}/utxo", as.HandleAddrUTXO).Methods("GET")
+	router.HandleFunc("/addr/{addr}/balance", as.HandleAddrBalance).Methods("GET")
+	router.HandleFunc("/addr/{addr}/totalReceived", as.HandleAddrRecieved).Methods("GET")
+	router.HandleFunc("/addr/{addr}/totalSent", as.HandleAddrSent).Methods("GET")
+	router.HandleFunc("/tx/{txid}", as.HandleTxGet).Methods("GET")
+	router.HandleFunc("/rawtx/{txid}", as.HandleRawTxGet).Methods("GET")
+	router.HandleFunc("/messages/verify", as.HandleMessagesVerify).Methods("POST")
+	router.HandleFunc("/tx/send", as.HandleTransactionSend).Methods("POST")
+	router.HandleFunc("/block/{blockHash}", as.HandleGetBlock).Methods("GET")
+	router.HandleFunc("/block-index/{height}", as.HandleGetBlockHash).Methods("GET")
+	router.HandleFunc("/status", as.GetStatus).Methods("GET")
+	router.HandleFunc("/sync", as.GetSync).Methods("GET")
+	router.HandleFunc("/txs", as.GetTransactions).Methods("GET")
+	router.HandleFunc("/version", as.GetVersion).Methods("GET")
+
+	// router.HandleFunc("/test/{addr}", as.HandleTest).Methods("GET")
+
+	// router.HandleFunc("/addr/{addr}/unconfirmedBalance", as.HandleAddrUnconfirmed).Methods("GET")
+
+	// /insight-api/blocks?limit=3&blockDate=2016-04-22
+	// NOTE: this should fetch the last n blocks
+	// router.HandleFunc("/blocks", as.HandleGetBlocks).Methods("GET")
+
+	// NOTE: This pulls data from outside price APIs. Might want to implement a couple
+	// GET /currency
+	// router.HandleFunc("/currency", as.GetCurrency).Methods("GET")
+
+	return router
+}

--- a/addrindex/addrserver.go
+++ b/addrindex/addrserver.go
@@ -101,32 +101,32 @@ func (as *AddrServer) connCfg() *rpcclient.ConnConfig {
 
 // fetchAllTransactions pages through the transactions for an address
 // NOTE: This can take a long time!
-func (as *AddrServer) fetchAllTransactions(addr string) (Transactions, error) {
-	txns := []Transaction{}
-	count := 0
-	for {
-		// Fetch page of transactions
-		searchtxns, err := as.SearchRawTransactions(addr, (count * as.Transactions), as.Transactions)
-		if err != nil {
-			return nil, err
-		}
-
-		// Increment page count
-		count++
-
-		// If the page is full we need to append them and continue to next page
-		if len(searchtxns.Result) == as.Transactions {
-			for _, tx := range searchtxns.Result {
-				txns = append(txns, tx)
-			}
-			continue
-		}
-
-		// If not we need to save the tansactions and return
-		for _, tx := range searchtxns.Result {
-			txns = append(txns, tx)
-		}
-
-		return txns, nil
-	}
-}
+// func (as *AddrServer) fetchAllTransactions(addr string) (Transactions, error) {
+// 	txns := []Transaction{}
+// 	count := 0
+// 	for {
+// 		// Fetch page of transactions
+// 		searchtxns, err := as.SearchRawTransactions(addr, (count * as.Transactions), as.Transactions)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+//
+// 		// Increment page count
+// 		count++
+//
+// 		// If the page is full we need to append them and continue to next page
+// 		if len(searchtxns.Result) == as.Transactions {
+// 			for _, tx := range searchtxns.Result {
+// 				txns = append(txns, tx)
+// 			}
+// 			continue
+// 		}
+//
+// 		// If not we need to save the tansactions and return
+// 		for _, tx := range searchtxns.Result {
+// 			txns = append(txns, tx)
+// 		}
+//
+// 		return txns, nil
+// 	}
+// }

--- a/addrindex/addrserver.go
+++ b/addrindex/addrserver.go
@@ -17,6 +17,7 @@ package addrindex
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/gorilla/mux"
@@ -57,6 +58,12 @@ type AddrServerConfig struct {
 	Version      string
 	Commit       string
 	Branch       string
+}
+
+type CurrencyData struct {
+	Binance float64
+
+	sync.Mutex
 }
 
 // NewAddrServer returns a new AddrServer instance
@@ -119,9 +126,8 @@ func (as *AddrServer) Router() *mux.Router {
 	router.HandleFunc("/txs", as.GetTransactions).Methods("GET")
 	router.HandleFunc("/version", as.GetVersion).Methods("GET")
 
-	// router.HandleFunc("/test/{addr}", as.HandleTest).Methods("GET")
-
-	// router.HandleFunc("/addr/{addr}/unconfirmedBalance", as.HandleAddrUnconfirmed).Methods("GET")
+	// NOTE: This route only returns the satoshi amount of confirmed transactions
+	router.HandleFunc("/addr/{addr}/unconfirmedBalance", as.HandleAddrUnconfirmedBalance).Methods("GET")
 
 	// /insight-api/blocks?limit=3&blockDate=2016-04-22
 	// NOTE: this should fetch the last n blocks

--- a/addrindex/addrserver.go
+++ b/addrindex/addrserver.go
@@ -106,9 +106,9 @@ func NewAddrServer(cfg *AddrServerConfig) *AddrServer {
 		panic(err)
 	}
 	out.Client = client
-	out.RefreshBlocks()
-	go out.updateCurrency()
-	go out.updateBlocks()
+	// out.RefreshBlocks()
+	// go out.updateCurrency()
+	// go out.updateBlocks()
 	return out
 }
 

--- a/addrindex/addrserver.go
+++ b/addrindex/addrserver.go
@@ -39,6 +39,7 @@ type AddrServer struct {
 }
 
 func (as *AddrServer) updateCurrency() {
+	fmt.Println("timeout", as.Timeout)
 	ticker := time.NewTicker(time.Second * time.Duration(as.Timeout))
 	for _ = range ticker.C {
 		bn := binancePrice()
@@ -108,6 +109,31 @@ func NewAddrServer(cfg *AddrServerConfig) *AddrServer {
 	out.RefreshBlocks()
 	go out.updateCurrency()
 	go out.updateBlocks()
+	return out
+}
+
+// NewTestAddrServer returns a new AddrServer instance
+func NewTestAddrServer(cfg *AddrServerConfig) *AddrServer {
+	out := &AddrServer{
+		Host:       cfg.Host,
+		User:       cfg.Usr,
+		Pass:       cfg.Pass,
+		DisableTLS: !cfg.SSL,
+		Port:       cfg.Port,
+		Timeout:    cfg.Timeout,
+		versionData: versionData{
+			Version: cfg.Version,
+			Commit:  cfg.Commit,
+			Branch:  cfg.Branch,
+		},
+		Blocks:       &Blocks{},
+		CurrencyData: NewCurrencyData(),
+	}
+	client, err := rpcclient.New(out.connCfg(), nil)
+	if err != nil {
+		panic(err)
+	}
+	out.Client = client
 	return out
 }
 

--- a/addrindex/bitcore-methods.go
+++ b/addrindex/bitcore-methods.go
@@ -139,16 +139,6 @@ type GetAddressDeltasResponse struct {
 	ID     interface{}    `json:"id"`
 }
 
-// AddressDelta represents a balance change for an address
-type AddressDelta struct {
-	Satoshis   int    `json:"satoshis"`
-	Txid       string `json:"txid"`
-	Index      int    `json:"index"`
-	Blockindex int    `json:"blockindex"`
-	Height     int    `json:"height"`
-	Address    string `json:"address"`
-}
-
 func getAddressBalanceRequest(addresses []string) []byte {
 	srtr := BitcoreRequest{
 		JSONRPC: "1.0",
@@ -197,12 +187,6 @@ type GetAddressBalanceResult struct {
 	ID     interface{}    `json:"id"`
 }
 
-// AddressBalance is the balance of an address
-type AddressBalance struct {
-	Balance  int `json:"balance"`
-	Received int `json:"received"`
-}
-
 func getAddressUTXORequest(addresses []string) []byte {
 	srtr := BitcoreRequest{
 		JSONRPC: "1.0",
@@ -249,16 +233,6 @@ type GetAddressUTXOsResponse struct {
 	Result []UTXOIns   `json:"result"`
 	Error  interface{} `json:"error"`
 	ID     interface{} `json:"id"`
-}
-
-// UTXOIns is an insight representation of a UTXO
-type UTXOIns struct {
-	Address     string `json:"address"`
-	Txid        string `json:"txid"`
-	OutputIndex int    `json:"outputIndex"`
-	Script      string `json:"script"`
-	Satoshis    int    `json:"satoshis"`
-	Height      int    `json:"height"`
 }
 
 func getAddressMempoolRequest(addresses []string) []byte {
@@ -318,19 +292,6 @@ type GetAddressMempoolResponse struct {
 	Result []AddrMempoolTransaction `json:"result"`
 	Error  interface{}              `json:"error"`
 	ID     interface{}              `json:"id"`
-}
-
-// AddrMempoolTransaction represents a transaction in the mempool
-// prevtxid and prevout that can be used for marking utxos as spent
-// Instead of height there is timestamp that is the time the transaction entered the mempool
-type AddrMempoolTransaction []struct {
-	Address   string `json:"address"`
-	Txid      string `json:"txid"`
-	Index     int    `json:"index"`
-	Satoshis  int    `json:"satoshis"`
-	Timestamp int    `json:"timestamp"`
-	Prevtxid  string `json:"prevtxid,omitempty"`
-	Prevout   int    `json:"prevout,omitempty"`
 }
 
 func getBlockHashesRequest(start, end int) []byte {
@@ -427,13 +388,6 @@ type GetSpentInfoResponse struct {
 	ID     interface{} `json:"id"`
 }
 
-// SpentInfo contains data about spent transaction outputs
-type SpentInfo struct {
-	Txid   string `json:"txid"`
-	Index  int    `json:"index"`
-	Height int    `json:"height"`
-}
-
 // getRawTransactionRequest formats the json payload for the getrawtransaction RPC
 func getRawTransactionRequest(addresses string) []byte {
 	srtr := BitcoreRequest{
@@ -484,20 +438,4 @@ type GetRawTransactionResponse struct {
 	Result TransactionIns `json:"result"`
 	Error  interface{}    `json:"error"`
 	ID     interface{}    `json:"id"`
-}
-
-// TransactionIns is the response struct for GetRawTransaction
-type TransactionIns struct {
-	Hex           string    `json:"hex"`
-	Txid          string    `json:"txid"`
-	Size          int       `json:"size"`
-	Version       int       `json:"version"`
-	Locktime      int       `json:"locktime"`
-	Vin           []VinIns  `json:"vin"`
-	Vout          []VoutIns `json:"vout"`
-	Blockhash     string    `json:"blockhash"`
-	Height        int       `json:"height"`
-	Confirmations int       `json:"confirmations"`
-	Time          int       `json:"time"`
-	Blocktime     int       `json:"blocktime"`
 }

--- a/addrindex/bitcore-methods.go
+++ b/addrindex/bitcore-methods.go
@@ -297,7 +297,7 @@ type GetAddressMempoolResponse struct {
 func getBlockHashesRequest(start, end int) []byte {
 	srtr := BitcoreRequest{
 		JSONRPC: "1.0",
-		Method:  "searchrawtransactions",
+		Method:  "getblockhashes",
 		Params:  []interface{}{start, end},
 	}
 	out, err := json.Marshal(srtr)
@@ -308,9 +308,9 @@ func getBlockHashesRequest(start, end int) []byte {
 }
 
 // GetBlockHashes returns blockhashes between two unix epoch timestamps (seconds)
-func (as *AddrServer) GetBlockHashes(start, end int) (GetBlockHashesResponse, error) {
+func (as *AddrServer) GetBlockHashes(end, start int) (GetBlockHashesResponse, error) {
 	out := GetBlockHashesResponse{}
-	req, err := http.NewRequest("POST", as.URL(), bytes.NewBuffer(getBlockHashesRequest(start, end)))
+	req, err := http.NewRequest("POST", as.URL(), bytes.NewBuffer(getBlockHashesRequest(end, start)))
 	if err != nil {
 		return out, err
 	}
@@ -345,7 +345,7 @@ func getSpentInfoRequest(txid string, index int) []byte {
 	srtr := BitcoreRequest{
 		JSONRPC: "1.0",
 		Method:  "getspentinfo",
-		Params:  []interface{}{map[string]interface{}{"tx": txid, "index": index}},
+		Params:  []interface{}{map[string]interface{}{"txid": txid, "index": index}},
 	}
 	out, err := json.Marshal(srtr)
 	if err != nil {
@@ -374,6 +374,7 @@ func (as *AddrServer) GetSpentInfo(txid string, index int) (GetSpentInfoResponse
 	if err != nil {
 		return out, err
 	}
+
 	err = json.Unmarshal(body, &out)
 	if err != nil {
 		return out, err

--- a/addrindex/bitcore-methods_test.go
+++ b/addrindex/bitcore-methods_test.go
@@ -17,12 +17,13 @@ var (
 )
 
 func bitcoreTestSetup() *AddrServer {
-	return NewAddrServer(&AddrServerConfig{
+	return NewTestAddrServer(&AddrServerConfig{
 		Host:    testServer,
 		Usr:     testUser,
 		Pass:    testPass,
 		SSL:     testSSL,
 		Port:    testPort,
+		Timeout: 300,
 		Version: "test",
 		Commit:  "test",
 		Branch:  "test",

--- a/addrindex/bitcore-methods_test.go
+++ b/addrindex/bitcore-methods_test.go
@@ -1,0 +1,168 @@
+package addrindex
+
+import (
+	"testing"
+)
+
+var (
+	testExpectedAddrTxns    = 4983
+	testExpectedAddrDeltas  = 9965
+	startBlock              = 300000
+	endBlock                = 500000
+	testBlockEndTime        = 1519237038
+	testBlockStartTime      = 1519064238
+	testExpectedBlockHashes = 311
+	testTransactionIndex    = 1
+	testExpectedTxid        = "b3922b88ba526df9cab9634785892de245004c96c36ede9b5b50f68abe584e98"
+)
+
+func bitcoreTestSetup() *AddrServer {
+	return NewAddrServer(&AddrServerConfig{
+		Host:    testServer,
+		Usr:     testUser,
+		Pass:    testPass,
+		SSL:     testSSL,
+		Port:    testPort,
+		Version: "test",
+		Commit:  "test",
+		Branch:  "test",
+	})
+}
+
+func TestGetAddressTxIDs(t *testing.T) {
+	t.Parallel()
+	as := bitcoreTestSetup()
+	out, err := as.GetAddressTxIDs([]string{testAddress}, startBlock, endBlock)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(out.Result) != testExpectedAddrTxns {
+		t.Fatalf("Expected '%d' transactions, got '%d'\n", testExpectedAddrTxns, len(out.Result))
+	}
+}
+
+func TestGetAddressDeltas(t *testing.T) {
+	t.Parallel()
+	as := bitcoreTestSetup()
+	out, err := as.GetAddressDeltas([]string{testAddress}, startBlock, endBlock)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(out.Result) != testExpectedAddrDeltas {
+		t.Fatalf("Expected '%d' deltas, got '%d'\n", testExpectedAddrDeltas, len(out.Result))
+	}
+}
+
+func TestGetAddressBalance(t *testing.T) {
+	t.Parallel()
+	as := bitcoreTestSetup()
+	out, err := as.GetAddressBalance([]string{testAddress})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Result.Balance != testExpectedBalance {
+		t.Fatalf("Expected '%d' satoshi, got '%d'\n", testExpectedBalance, out.Result.Balance)
+	}
+}
+
+func TestGetAddressUTXOs(t *testing.T) {
+	t.Parallel()
+	as := bitcoreTestSetup()
+	out, err := as.GetAddressUTXOs([]string{testAddress})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(out.Result) != testExpectedUTXO {
+		t.Fatalf("Expected '%d' utxo, got '%d'\n", testExpectedUTXO, len(out.Result))
+	}
+
+	if out.Result[0].Satoshis != testExpectedUTXOSatoshi {
+		t.Fatalf("Expected '%d' satoshi, got '%d'\n", testExpectedUTXO, len(out.Result))
+	}
+}
+
+func TestGetAddressMempool(t *testing.T) {
+	t.Parallel()
+	as := bitcoreTestSetup()
+
+	// Fetch the raw mempool from the server
+	mp, err := as.Client.GetRawMempool()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fetch details for one of those transactions
+	tx := mp[0].String()
+	raw, err := as.GetRawTransaction(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run GetAddressMempool with the resulting address
+	address := raw.Result.Vout[0].ScriptPubKey.Addresses[0]
+	out, err := as.GetAddressMempool([]string{address})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check results for instances of that address
+	ok := false
+	for _, tx := range out.Result {
+		if tx.Address == address {
+			ok = true
+		}
+	}
+
+	if !ok {
+		t.Fatalf("Expected to find address %s from transaction %s in mempool. That address was not found.", address, tx)
+	}
+}
+
+func TestGetBlockHashes(t *testing.T) {
+	t.Parallel()
+	as := bitcoreTestSetup()
+
+	hashes, err := as.GetBlockHashes(testBlockEndTime, testBlockStartTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hashes.Result) != testExpectedBlockHashes {
+		t.Fatalf("Expected to find %d block hashes between %d and %d, but found %d", testExpectedBlockHashes, testBlockEndTime, testBlockStartTime, len(hashes.Result))
+	}
+}
+
+func TestGetSpentInfo(t *testing.T) {
+	t.Parallel()
+	as := bitcoreTestSetup()
+
+	spent, err := as.GetSpentInfo(testTransaction, testTransactionIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if spent.Result.Txid != testExpectedTxid {
+		t.Fatalf("Expected output 0 from tx %s to have been spent by %s, but was spent by %s", testTransaction, testExpectedTxid, spent.Result.Txid)
+	}
+}
+
+func TestGetRawTransaction(t *testing.T) {
+	t.Parallel()
+	as := bitcoreTestSetup()
+	txn, err := as.GetRawTransaction(testTransaction)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if txn.Result.Vin[0].ValueSat != testExpectedTxSatoshi {
+		t.Errorf("Expected '%d' satoshi in vin 0, got '%d'\n", testExpectedTxSatoshi, txn.Result.Vin[0].ValueSat)
+	}
+}

--- a/addrindex/bitcore-schema.go
+++ b/addrindex/bitcore-schema.go
@@ -39,25 +39,18 @@ type ScriptSig struct {
 
 // TransactionIns is the response struct for GetRawTransaction
 type TransactionIns struct {
-	Hex           string    `json:"hex"`
-	Txid          string    `json:"txid"`
-	Size          int       `json:"size"`
-	Version       int       `json:"version"`
-	Locktime      int       `json:"locktime"`
-	Vin           []VinIns  `json:"vin"`
-	Vout          []VoutIns `json:"vout"`
-	Blockhash     string    `json:"blockhash"`
-	Height        int       `json:"height"`
-	Confirmations int       `json:"confirmations"`
-	Time          int       `json:"time"`
-	Blocktime     int       `json:"blocktime"`
-}
-
-// SpentInfo contains data about spent transaction outputs
-type SpentInfo struct {
-	Txid   string `json:"txid"`
-	Index  int    `json:"index"`
-	Height int    `json:"height"`
+	Hex           string    `json:"hex,omitempty"`
+	Txid          string    `json:"txid,omitempty"`
+	Size          int       `json:"size,omitempty"`
+	Version       int       `json:"version,omitempty"`
+	Locktime      int       `json:"locktime,omitempty"`
+	Vin           []VinIns  `json:"vin,omitempty"`
+	Vout          []VoutIns `json:"vout,omitempty"`
+	Blockhash     string    `json:"blockhash,omitempty"`
+	Height        int       `json:"height,omitempty"`
+	Confirmations int       `json:"confirmations,omitempty"`
+	Time          int       `json:"time,omitempty"`
+	Blocktime     int       `json:"blocktime,omitempty"`
 }
 
 // AddrMempoolTransaction represents a transaction in the mempool
@@ -73,14 +66,39 @@ type AddrMempoolTransaction struct {
 	Prevout   int    `json:"prevout,omitempty"`
 }
 
+func (amp AddrMempoolTransaction) UTXO() UTXOIns {
+	return UTXOIns{
+		Address:       amp.Address,
+		Txid:          amp.Txid,
+		OutputIndex:   amp.Index,
+		Satoshis:      amp.Satoshis,
+		Amount:        float64(amp.Satoshis) / 100000000,
+		Confirmations: 0,
+	}
+}
+
 // UTXOIns is an insight representation of a UTXO
 type UTXOIns struct {
-	Address     string `json:"address"`
-	Txid        string `json:"txid"`
-	OutputIndex int    `json:"outputIndex"`
-	Script      string `json:"script"`
-	Satoshis    int    `json:"satoshis"`
-	Height      int    `json:"height"`
+	Address       string  `json:"address"`
+	Txid          string  `json:"txid"`
+	OutputIndex   int     `json:"outputIndex"`
+	Script        string  `json:"script,omitempty"`
+	Satoshis      int     `json:"satoshis,omitempty"`
+	Amount        float64 `json:"amount,omitempty"`
+	Height        int     `json:"height,omitempty"`
+	Confirmations int     `json:"confirmations"`
+}
+
+func (utxo UTXOIns) Enrich(blockHeight int) {
+	utxo.Confirmations = blockHeight - utxo.Height
+	utxo.Amount = float64(utxo.Satoshis) / 100000000
+}
+
+// SpentInfo contains data about spent transaction outputs
+type SpentInfo struct {
+	Txid   string `json:"txid"`
+	Index  int    `json:"index"`
+	Height int    `json:"height"`
 }
 
 // AddressBalance is the balance of an address

--- a/addrindex/bitcore-schema.go
+++ b/addrindex/bitcore-schema.go
@@ -66,7 +66,7 @@ type AddrMempoolTransaction struct {
 	Prevout   int    `json:"prevout,omitempty"`
 }
 
-// UTXO is a thing
+// UTXO takes a mempool transaction and converts it into the output format for /addr/<addr>/utxo
 func (amp AddrMempoolTransaction) UTXO() UTXOInsOut {
 	return UTXOInsOut{
 		Address:       amp.Address,
@@ -92,15 +92,20 @@ type UTXOIns struct {
 	Confirmations int     `json:"confirmations"`
 }
 
-// UTXOInsOuts for sorting
+// UTXOInsOuts is a collection with methods defined for sorting
 type UTXOInsOuts []UTXOInsOut
 
+// Len implements sort for UTXOInsOuts
 func (s UTXOInsOuts) Len() int {
 	return len(s)
 }
+
+// Swap implements sort for UTXOInsOuts
 func (s UTXOInsOuts) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
+
+// Less implements sort for UTXOInsOuts
 func (s UTXOInsOuts) Less(i, j int) bool {
 	return s[i].Confirmations < s[j].Confirmations
 }
@@ -118,7 +123,7 @@ type UTXOInsOut struct {
 	Confirmations int     `json:"confirmations"`
 }
 
-// Enrich is enriching
+// Enrich adds data to a utxo to make the output format
 func (utxo UTXOIns) Enrich(blockHeight int32) UTXOInsOut {
 	return UTXOInsOut{
 		Address:       utxo.Address,

--- a/addrindex/bitcore-schema.go
+++ b/addrindex/bitcore-schema.go
@@ -1,0 +1,38 @@
+package addrindex
+
+// VinIns is the bitcore representation of a Vin
+type VinIns struct {
+	Txid      string    `json:"txid"`
+	Vout      int       `json:"vout"`
+	ScriptSig ScriptSig `json:"scriptSig"`
+	Value     float64   `json:"value"`
+	ValueSat  int       `json:"valueSat"`
+	Address   string    `json:"address"`
+	Sequence  int64     `json:"sequence"`
+}
+
+// ScriptPubKeyIns is the bitcore representation of a ScriptPubKey
+type ScriptPubKeyIns struct {
+	Asm       string   `json:"asm"`
+	Hex       string   `json:"hex"`
+	ReqSigs   int      `json:"reqSigs"`
+	Type      string   `json:"type"`
+	Addresses []string `json:"addresses"`
+}
+
+// VoutIns is the bitcore representation of a Vout
+type VoutIns struct {
+	Value        float64         `json:"value"`
+	ValueSat     int             `json:"valueSat"`
+	N            int             `json:"n"`
+	ScriptPubKey ScriptPubKeyIns `json:"scriptPubKey"`
+	SpentTxID    string          `json:"spentTxId,omitempty"`
+	SpentIndex   int             `json:"spentIndex,omitempty"`
+	SpentHeight  int             `json:"spentHeight,omitempty"`
+}
+
+// ScriptSig models the scriptSig portion of a vin
+type ScriptSig struct {
+	Asm string `json:"asm"`
+	Hex string `json:"hex"`
+}

--- a/addrindex/bitcore-schema.go
+++ b/addrindex/bitcore-schema.go
@@ -36,3 +36,65 @@ type ScriptSig struct {
 	Asm string `json:"asm"`
 	Hex string `json:"hex"`
 }
+
+// TransactionIns is the response struct for GetRawTransaction
+type TransactionIns struct {
+	Hex           string    `json:"hex"`
+	Txid          string    `json:"txid"`
+	Size          int       `json:"size"`
+	Version       int       `json:"version"`
+	Locktime      int       `json:"locktime"`
+	Vin           []VinIns  `json:"vin"`
+	Vout          []VoutIns `json:"vout"`
+	Blockhash     string    `json:"blockhash"`
+	Height        int       `json:"height"`
+	Confirmations int       `json:"confirmations"`
+	Time          int       `json:"time"`
+	Blocktime     int       `json:"blocktime"`
+}
+
+// SpentInfo contains data about spent transaction outputs
+type SpentInfo struct {
+	Txid   string `json:"txid"`
+	Index  int    `json:"index"`
+	Height int    `json:"height"`
+}
+
+// AddrMempoolTransaction represents a transaction in the mempool
+// prevtxid and prevout that can be used for marking utxos as spent
+// Instead of height there is timestamp that is the time the transaction entered the mempool
+type AddrMempoolTransaction []struct {
+	Address   string `json:"address"`
+	Txid      string `json:"txid"`
+	Index     int    `json:"index"`
+	Satoshis  int    `json:"satoshis"`
+	Timestamp int    `json:"timestamp"`
+	Prevtxid  string `json:"prevtxid,omitempty"`
+	Prevout   int    `json:"prevout,omitempty"`
+}
+
+// UTXOIns is an insight representation of a UTXO
+type UTXOIns struct {
+	Address     string `json:"address"`
+	Txid        string `json:"txid"`
+	OutputIndex int    `json:"outputIndex"`
+	Script      string `json:"script"`
+	Satoshis    int    `json:"satoshis"`
+	Height      int    `json:"height"`
+}
+
+// AddressBalance is the balance of an address
+type AddressBalance struct {
+	Balance  int `json:"balance"`
+	Received int `json:"received"`
+}
+
+// AddressDelta represents a balance change for an address
+type AddressDelta struct {
+	Satoshis   int    `json:"satoshis"`
+	Txid       string `json:"txid"`
+	Index      int    `json:"index"`
+	Blockindex int    `json:"blockindex"`
+	Height     int    `json:"height"`
+	Address    string `json:"address"`
+}

--- a/addrindex/bitcore-schema.go
+++ b/addrindex/bitcore-schema.go
@@ -63,7 +63,7 @@ type SpentInfo struct {
 // AddrMempoolTransaction represents a transaction in the mempool
 // prevtxid and prevout that can be used for marking utxos as spent
 // Instead of height there is timestamp that is the time the transaction entered the mempool
-type AddrMempoolTransaction []struct {
+type AddrMempoolTransaction struct {
 	Address   string `json:"address"`
 	Txid      string `json:"txid"`
 	Index     int    `json:"index"`

--- a/addrindex/blocks.go
+++ b/addrindex/blocks.go
@@ -1,0 +1,84 @@
+package addrindex
+
+import (
+	"encoding/json"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+// Blocks represents the cached /blocks response
+type Blocks struct {
+	Blocks []GetBlocksResponse `json:"blocks"`
+	Length int                 `json:"length"`
+	sync.Mutex
+}
+
+// RefreshBlocks pulls new values for the blocks
+func (as *AddrServer) RefreshBlocks() {
+	limit := 11
+	now := time.Now()
+	blocks, err := as.GetBlockHashes(int(now.Unix()), int(now.Add(-24*time.Hour).Unix()))
+	if err != nil {
+		log.Println("Failed fetching block hashes")
+	}
+	var toQuery []string
+	for i := len(blocks.Result) - 1; i >= 0; i-- {
+		toQuery = append(toQuery, blocks.Result[i])
+	}
+	toQuery = toQuery[:limit]
+
+	var out []GetBlocksResponse
+	for _, blh := range toQuery {
+		blockHash, err := chainhash.NewHashFromStr(blh)
+		if err != nil {
+			log.Println("Failed creating chainhash from block data")
+			continue
+		}
+		block, err := as.Client.GetBlockVerbose(blockHash)
+		if err != nil {
+			log.Println("Failed fetching block data")
+			return
+		}
+		out = append(out, newGetBlockResponse(block))
+	}
+	as.Blocks.Lock()
+	as.Blocks.Length = limit
+	as.Blocks.Blocks = out
+	as.Blocks.Unlock()
+}
+
+// JSON returns the JSON representation of Blocks
+func (b *Blocks) JSON() []byte {
+	o, _ := json.Marshal(b)
+	return o
+}
+
+func newGetBlockResponse(blk *btcjson.GetBlockVerboseResult) GetBlocksResponse {
+	return GetBlocksResponse{
+		Height:   blk.Height,
+		Size:     blk.Weight,
+		Hash:     blk.Hash,
+		Time:     blk.Time,
+		Txlength: len(blk.Tx),
+	}
+}
+
+// GetBlocksResponse formats the response for the GetBlocks route
+type GetBlocksResponse struct {
+	Height   int64    `json:"height"`
+	Size     int32    `json:"size"`
+	Hash     string   `json:"hash"`
+	Time     int64    `json:"time"`
+	Txlength int      `json:"txlength"`
+	PoolInfo PoolInfo `json:"poolInfo"`
+}
+
+// PoolInfo represents the mining pool information
+type PoolInfo struct {
+	PoolName string `json:"poolName,omitempty"`
+	URL      string `json:"url,omitempty"`
+}

--- a/addrindex/blocks.go
+++ b/addrindex/blocks.go
@@ -24,6 +24,7 @@ func (as *AddrServer) RefreshBlocks() {
 	blocks, err := as.GetBlockHashes(int(now.Unix()), int(now.Add(-24*time.Hour).Unix()))
 	if err != nil {
 		log.Println("Failed fetching block hashes")
+		return
 	}
 	var toQuery []string
 	for i := len(blocks.Result) - 1; i >= 0; i-- {

--- a/addrindex/prices.go
+++ b/addrindex/prices.go
@@ -6,43 +6,36 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-	"sync"
 )
 
 // NewCurrencyData returns the struct that manages currency data
 func NewCurrencyData() *CurrencyData {
 	cd := &CurrencyData{}
-	cd.Refresh()
+	cd.Get()
 	return cd
 }
 
 // CurrencyData represents the current BTC price from a couple of providers
 type CurrencyData struct {
-	Binance        float64 `json:"binance"`
-	BlockchainInfo float64 `json:"blockchainInfo"`
-	Coinbase       float64 `json:"coinbase"`
-
-	sync.Mutex
+	Status int `json:"status"`
+	Data   struct {
+		Binance        float64 `json:"binance"`
+		BlockchainInfo float64 `json:"blockchainInfo"`
+		Coinbase       float64 `json:"coinbase"`
+	} `json:"data"`
 }
 
 // JSON returns the json representation of CurrencyData
 func (c *CurrencyData) JSON() []byte {
-	c.Lock()
 	out, _ := json.Marshal(c)
-	c.Unlock()
 	return out
 }
 
 // Refresh refreshes the bitcoin price for the currency info struct
-func (c *CurrencyData) Refresh() {
-	bn := binancePrice()
-	bi := blockchainInfoPrice()
-	cb := coinbasePrice()
-	c.Lock()
-	c.Binance = bn
-	c.BlockchainInfo = bi
-	c.Coinbase = cb
-	c.Unlock()
+func (c *CurrencyData) Get() {
+	c.Data.Binance = binancePrice()
+	c.Data.BlockchainInfo = blockchainInfoPrice()
+	c.Data.Coinbase = coinbasePrice()
 }
 
 type getBinancePriceResponse struct {

--- a/addrindex/prices.go
+++ b/addrindex/prices.go
@@ -1,0 +1,174 @@
+package addrindex
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+	"sync"
+)
+
+// NewCurrencyData returns the struct that manages currency data
+func NewCurrencyData() *CurrencyData {
+	cd := &CurrencyData{}
+	cd.Refresh()
+	return cd
+}
+
+// CurrencyData represents the current BTC price from a couple of providers
+type CurrencyData struct {
+	Binance        float64 `json:"binance"`
+	BlockchainInfo float64 `json:"blockchainInfo"`
+	Coinbase       float64 `json:"coinbase"`
+
+	sync.Mutex
+}
+
+// JSON returns the json representation of CurrencyData
+func (c *CurrencyData) JSON() []byte {
+	c.Lock()
+	out, _ := json.Marshal(c)
+	c.Unlock()
+	return out
+}
+
+// Refresh refreshes the bitcoin price for the currency info struct
+func (c *CurrencyData) Refresh() {
+	bn := binancePrice()
+	bi := blockchainInfoPrice()
+	cb := coinbasePrice()
+	c.Lock()
+	c.Binance = bn
+	c.BlockchainInfo = bi
+	c.Coinbase = cb
+	c.Unlock()
+}
+
+type getBinancePriceResponse struct {
+	High      string  `json:"high"`
+	Last      string  `json:"last"`
+	Timestamp string  `json:"timestamp"`
+	Bid       string  `json:"bid"`
+	Vwap      string  `json:"vwap"`
+	Volume    string  `json:"volume"`
+	Low       string  `json:"low"`
+	Ask       string  `json:"ask"`
+	Open      float64 `json:"open"`
+}
+
+type getCoinbasePriceResponse struct {
+	Data struct {
+		Base     string `json:"base"`
+		Currency string `json:"currency"`
+		Amount   string `json:"amount"`
+	} `json:"data"`
+}
+
+func blockchainInfoPrice() float64 {
+	req, err := http.NewRequest("GET", "https://blockchain.info/tobtc?currency=usd&value=1000", nil)
+	if err != nil {
+		log.Println("Failed updating coinbase price - request creation failed")
+		return 0.0
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Println("Failed updating coinbase price - call failed")
+		return 0.0
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println("Failed updating coinbase price - failed reading body")
+		return 0.0
+	}
+
+	o, err := strconv.ParseFloat(string(body), 64)
+	if err != nil {
+		log.Println("Failed updating coinbase price - failed parsing float")
+		return 0.0
+	}
+
+	return (1 / o) * 1000
+}
+
+func coinbasePrice() float64 {
+	out := getCoinbasePriceResponse{}
+	req, err := http.NewRequest("GET", "https://api.coinbase.com/v2/prices/spot?currency=USD", nil)
+	if err != nil {
+		log.Println("Failed updating coinbase price - request creation failed")
+		return 0.0
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("CB-VERSION", "2015-04-08")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Println("Failed updating coinbase price - call failed")
+		return 0.0
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println("Failed updating coinbase price - failed reading body")
+		return 0.0
+	}
+
+	err = json.Unmarshal(body, &out)
+	if err != nil {
+		log.Println("Failed updating coinbase price - failed unmarshalling json")
+		return 0.0
+	}
+
+	o, err := strconv.ParseFloat(out.Data.Amount, 64)
+	if err != nil {
+		log.Println("Failed updating coinbase price - failed parsing float")
+		return 0.0
+	}
+
+	return o
+}
+
+func binancePrice() float64 {
+	out := getBinancePriceResponse{}
+	req, err := http.NewRequest("GET", "https://www.bitstamp.net/api/ticker/", nil)
+	if err != nil {
+		log.Println("Failed updating binance price - request creation failed")
+		return 0.0
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Println("Failed updating binance price - call failed")
+		return 0.0
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Println("Failed updating binance price - failed reading body")
+		return 0.0
+	}
+
+	err = json.Unmarshal(body, &out)
+	if err != nil {
+		log.Println("Failed updating binance price - failed unmarshalling json")
+		return 0.0
+	}
+
+	o, err := strconv.ParseFloat(out.Last, 64)
+	if err != nil {
+		log.Println("Failed updating binance price - failed parsing float")
+		return 0.0
+	}
+
+	return o
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,135 @@
+package cache
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	r "gopkg.in/redis.v5"
+)
+
+//Storage mecanism for caching strings
+type Storage interface {
+	Get(key string) []byte
+	Set(key string, content []byte, duration time.Duration)
+}
+
+const preffix = "_PAGE_CACHE_"
+
+// RedisCache storage mecanism for caching strings in memory
+type RedisCache struct {
+	client *r.Client
+}
+
+// NewRedisCache creates a new redis storage
+func NewRedisCache(url string) (*RedisCache, error) {
+	var (
+		opts *r.Options
+		err  error
+	)
+
+	if opts, err = r.ParseURL(url); err != nil {
+		return nil, err
+	}
+
+	return &RedisCache{
+		client: r.NewClient(opts),
+	}, nil
+}
+
+// Get a cached content by key
+func (c RedisCache) Get(key string) []byte {
+	val, _ := c.client.Get(preffix + key).Bytes()
+	return val
+}
+
+// Set a cached content by key
+func (c RedisCache) Set(key string, content []byte, duration time.Duration) {
+	c.client.Set(preffix+key, content, duration)
+}
+
+// MEMORY CACHE
+
+// Item is a cached reference
+type Item struct {
+	Content    []byte
+	Expiration int64
+}
+
+// Expired returns true if the item has expired.
+func (item Item) Expired() bool {
+	if item.Expiration == 0 {
+		return false
+	}
+	return time.Now().UnixNano() > item.Expiration
+}
+
+// MemoryCache mecanism for caching strings in memory
+type MemoryCache struct {
+	items map[string]Item
+	mu    *sync.RWMutex
+}
+
+// NewMemoryCache creates a new in memory storage
+func NewMemoryCache() *MemoryCache {
+	return &MemoryCache{
+		items: make(map[string]Item),
+		mu:    &sync.RWMutex{},
+	}
+}
+
+// Get a cached content by key
+func (c MemoryCache) Get(key string) []byte {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	item := c.items[key]
+	if item.Expired() {
+		delete(c.items, key)
+		return nil
+	}
+	return item.Content
+}
+
+// Set a cached content by key
+func (c MemoryCache) Set(key string, content []byte, duration time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.items[key] = Item{
+		Content:    content,
+		Expiration: time.Now().Add(duration).UnixNano(),
+	}
+}
+
+// Middleware is the cache interface for http requests
+func Middleware(duration string, storage Storage, handler func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		content := storage.Get(r.RequestURI)
+		if content != nil {
+			w.Write(content)
+		} else {
+			c := httptest.NewRecorder()
+			handler(c, r)
+
+			for k, v := range c.HeaderMap {
+				w.Header()[k] = v
+			}
+
+			w.WriteHeader(c.Code)
+			content := c.Body.Bytes()
+
+			if d, err := time.ParseDuration(duration); err == nil {
+				storage.Set(r.RequestURI, content, d)
+			} else {
+				log.Printf("[server] Page not cached. err: %s\n", err)
+			}
+
+			w.Write(content)
+		}
+
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
 	"github.com/jackzampolin/addrindex-server/addrindex"
 	"github.com/spf13/cobra"
 )
@@ -34,36 +33,8 @@ var serveCmd = &cobra.Command{
 		as := addrindex.NewAddrServer(cfg)
 		defer as.Client.Shutdown()
 
-		router := mux.NewRouter()
-
-		router.HandleFunc("/addr/{addr}/utxo", as.HandleAddrUTXO).Methods("GET")
-		router.HandleFunc("/addr/{addr}/balance", as.HandleAddrBalance).Methods("GET")
-		router.HandleFunc("/addr/{addr}/totalReceived", as.HandleAddrRecieved).Methods("GET")
-		router.HandleFunc("/addr/{addr}/totalSent", as.HandleAddrSent).Methods("GET")
-		router.HandleFunc("/tx/{txid}", as.HandleTxGet).Methods("GET")
-		router.HandleFunc("/rawtx/{txid}", as.HandleRawTxGet).Methods("GET")
-		router.HandleFunc("/messages/verify", as.HandleMessagesVerify).Methods("POST")
-		router.HandleFunc("/tx/send", as.HandleTransactionSend).Methods("POST")
-		router.HandleFunc("/block/{blockHash}", as.HandleGetBlock).Methods("GET")
-		router.HandleFunc("/block-index/{height}", as.HandleGetBlockHash).Methods("GET")
-		router.HandleFunc("/status", as.GetStatus).Methods("GET")
-		router.HandleFunc("/sync", as.GetSync).Methods("GET")
-		router.HandleFunc("/txs", as.GetTransactions).Methods("GET")
-		router.HandleFunc("/version", as.GetVersion).Methods("GET")
-		// router.HandleFunc("/test/{addr}", as.HandleTest).Methods("GET")
-
-		// router.HandleFunc("/addr/{addr}/unconfirmedBalance", as.HandleAddrUnconfirmed).Methods("GET")
-
-		// /insight-api/blocks?limit=3&blockDate=2016-04-22
-		// NOTE: this should fetch the last n blocks
-		// router.HandleFunc("/blocks", as.HandleGetBlocks).Methods("GET")
-
-		// NOTE: This pulls data from outside price APIs. Might want to implement a couple
-		// GET /currency
-		// router.HandleFunc("/currency", as.GetCurrency).Methods("GET")
-
 		log.Println(fmt.Sprintf("Listening on port ':%v'...", as.Port))
-		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", as.Port), handlers.LoggingHandler(os.Stdout, router)))
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", as.Port), handlers.LoggingHandler(os.Stdout, as.Router())))
 	},
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -50,7 +50,7 @@ var serveCmd = &cobra.Command{
 		router.HandleFunc("/sync", as.GetSync).Methods("GET")
 		router.HandleFunc("/txs", as.GetTransactions).Methods("GET")
 		router.HandleFunc("/version", as.GetVersion).Methods("GET")
-		router.HandleFunc("/test/{addr}", as.HandleTest).Methods("GET")
+		// router.HandleFunc("/test/{addr}", as.HandleTest).Methods("GET")
 
 		// router.HandleFunc("/addr/{addr}/unconfirmedBalance", as.HandleAddrUnconfirmed).Methods("GET")
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -50,6 +50,7 @@ var serveCmd = &cobra.Command{
 		router.HandleFunc("/sync", as.GetSync).Methods("GET")
 		router.HandleFunc("/txs", as.GetTransactions).Methods("GET")
 		router.HandleFunc("/version", as.GetVersion).Methods("GET")
+		router.HandleFunc("/test/{addr}", as.HandleTest).Methods("GET")
 
 		// router.HandleFunc("/addr/{addr}/unconfirmedBalance", as.HandleAddrUnconfirmed).Methods("GET")
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -3,4 +3,4 @@ usr: user
 pass: password
 ssl: false
 port: 18332
-transactions: 50
+timeout: 300


### PR DESCRIPTION
This PR migrates the RPC calls from the `btcdrax/addrindex:v0.13.0.2` server to the `satoshilabs/bitcore:v0.14.1` server.

This is still WIP. There is a deployed version at `https://utxo.technofractal.com`. Some of the routes there definitely don't work.